### PR TITLE
Add jsonp combinator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "type-proxy",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Validate data with unknown structure",
   "author": "Vivi International",
   "homepage": "https://github.com/viviedu/type-proxy",

--- a/src/combinator.ts
+++ b/src/combinator.ts
@@ -27,25 +27,12 @@ export const arrayP = <T>(type: TypeProxy<T>): TypeProxy<T[]> => (value) => {
   return { success: true, value: result };
 };
 
-export const defaultP = <T>(defaultValue: T, type: TypeProxy<T>): TypeProxy<T> => or2P(type, pureP(defaultValue));
-
-export const jsonP = <T>(type: TypeProxy<T>): TypeProxy<T> => (value) => {
-  if (typeof value !== 'string') {
-    return {
-      error: ParseError.simpleError(value, 'JSON string'),
-      success: false
-    };
-  }
-
-  try {
-    return type(JSON.parse(value));
-  } catch (error) {
-    return {
-      error: ParseError.simpleError(value, 'valid JSON'),
-      success: false,
-    };
-  }
+export const composeP = <A,B>(first: TypeProxy<A>, second: TypeProxy<B>): TypeProxy<B> => (value) => {
+  const result = first(value);
+  return result.success ? second(result.value) : result;
 };
+
+export const defaultP = <T>(defaultValue: T, type: TypeProxy<T>): TypeProxy<T> => or2P(type, pureP(defaultValue));
 
 export const labelP = <T>(label: string, type: TypeProxy<T>): TypeProxy<T> => (value) => {
   const result = type(value);

--- a/src/combinator.ts
+++ b/src/combinator.ts
@@ -29,6 +29,24 @@ export const arrayP = <T>(type: TypeProxy<T>): TypeProxy<T[]> => (value) => {
 
 export const defaultP = <T>(defaultValue: T, type: TypeProxy<T>): TypeProxy<T> => or2P(type, pureP(defaultValue));
 
+export const jsonP = <T>(type: TypeProxy<T>): TypeProxy<T> => (value) => {
+  if (typeof value !== 'string') {
+    return {
+      error: ParseError.simpleError(value, 'JSON string'),
+      success: false
+    };
+  }
+
+  try {
+    return type(JSON.parse(value));
+  } catch (error) {
+    return {
+      error: ParseError.simpleError(value, 'valid JSON'),
+      success: false,
+    };
+  }
+};
+
 export const labelP = <T>(label: string, type: TypeProxy<T>): TypeProxy<T> => (value) => {
   const result = type(value);
   return result.success === true

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { ParseError } from './error';
 export * from './combinator';
 export * from './error';
 export * from './functional';
+export * from './json';
 export * from './primitive';
 
 export type ParseResult<T> = {

--- a/src/json.ts
+++ b/src/json.ts
@@ -1,0 +1,23 @@
+import { ParseError, TypeProxy, labelP, stringP } from '.';
+
+export const jsonP: TypeProxy<unknown> = (value) => {
+  const result = labelP('JSON string', stringP)(value);
+  if (!result.success) {
+    return {
+      error: result.error,
+      success: false
+    };
+  }
+
+  try {
+    return {
+      success: true,
+      value: JSON.parse(result.value)
+    };
+  } catch (error) {
+    return {
+      error: ParseError.simpleError(value, 'valid JSON'),
+      success: false,
+    };
+  }
+};

--- a/src/json.ts
+++ b/src/json.ts
@@ -3,10 +3,7 @@ import { ParseError, TypeProxy, labelP, stringP } from '.';
 export const jsonP: TypeProxy<unknown> = (value) => {
   const result = labelP('JSON string', stringP)(value);
   if (!result.success) {
-    return {
-      error: result.error,
-      success: false
-    };
+    return result;
   }
 
   try {


### PR DESCRIPTION
Adds a `jsonP` combinator. This is convenient for using an existing type proxy on data that arrives as a JSON-encoded string.