### PR TITLE
VIVI-10105 Add unreachable() helper method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export * from './functional';
 export * from './json';
 export * from './primitive';
 export * from './transform';
+export * from './unreachable';
 
 export type ParseResult<T> = {
   success: true,

--- a/src/unreachable.ts
+++ b/src/unreachable.ts
@@ -1,4 +1,4 @@
-// this functions signifies code that is never executed. Typescript should
+// this functions signifies code that is never executed. TypeScript should
 // not allow this function to be in any real execution path at compile time.
 // see test file for example usage.
 export const unreachable = function (x: never): never {

--- a/src/unreachable.ts
+++ b/src/unreachable.ts
@@ -1,0 +1,6 @@
+// this functions signifies code that is never executed. Typescript should
+// not allow this function to be in any real execution path at compile time.
+// see test file for example usage.
+export const unreachable = function (x: never): never {
+  throw new Error(`Unreachable code executed: ${x}`);
+};

--- a/test/unreachable_test.ts
+++ b/test/unreachable_test.ts
@@ -1,0 +1,44 @@
+import { unreachable } from '../dist/index';
+
+describe('Helper unreachable()', () => {
+  // Example usage:
+  it('handles const boolean matches', () => {
+    const testThisFunctionShouldCompile = function () {
+      const x = true;
+      if (x) {
+        // do something
+      } else {
+        unreachable(x);
+      }
+    };
+
+    testThisFunctionShouldCompile();
+  });
+
+  // Example usage:
+  it('handles exhaustive boolean matches', () => {
+    const testExhaustiveBool = function (x: boolean) {
+      if (x === true) {
+        // do something
+      } else if (x === false) {
+        // do something
+      } else {
+        unreachable(x);
+      }
+    };
+
+    testExhaustiveBool(true);
+  });
+
+  it('handles other exhaustive matches', () => {
+    const testExhaustiveSwitch = function (x: 'one' | 'two') {
+      switch (x) {
+        case 'one': return;
+        case 'two': return;
+        default: unreachable(x);
+      }
+    };
+
+    testExhaustiveSwitch('one');
+  });
+});


### PR DESCRIPTION
The `unreachable()` helper is often used in conjunction with type proxies, to ensure that `switch` statements and other conditionals are exhaustive. The return type `never` ensures that, if the compiler does attempt to output code that executes this method, compilation will fail.

Tests have been included.