### PR TITLE
VIVI-15656 Update objectP to treat undefined values as optional

### DIFF
--- a/src/combinator.ts
+++ b/src/combinator.ts
@@ -89,7 +89,17 @@ export const nullableP = <T>(type: TypeProxy<T>): TypeProxy<T | null> => {
   return orP(type, nullP);
 };
 
-export const objectP = <T>(type: ObjectProxyHelper<T>): TypeProxy<T> => (value) => {
+type OptionalKeys<T> = {
+  [K in keyof T]: undefined extends T[K] ? K : never
+}[keyof T];
+
+type UndefinedToOptional<T extends object> = {
+  [K in Exclude<keyof T, OptionalKeys<T>>]: T[K];
+} & {
+  [K in OptionalKeys<T>]?: T[K];
+};
+
+export const objectP = <T extends object>(type: ObjectProxyHelper<T>): TypeProxy<UndefinedToOptional<T>> => (value) => {
   if (typeof value !== 'object' || value === null) {
     return { success: false, error: ParseError.simpleError(value, 'an object') };
   }


### PR DESCRIPTION
Currently something like:
```typescript
const testP = objectP(`{
  required: stringP,
  optional: optionalP(numberP),
});
```

Will result in a type like:
```typescript
type Test = {
  required: string;
  optional: number | undefined; // note the required but undefined field
}
```

Instead we want:
```typescript
type Test = {
  required: string;
  optional?: number | undefined; // now has ? meaning the field is optional
}
```

This PR makes necessary changes to allow that. This does mean that it's no longer possible to have fields that allow `undefined` but are required, which seems like a reasonable tradeoff.