### PR TITLE
VIVI-16673 Create the recordP type-proxy combinator

### DIFF
--- a/src/combinator.ts
+++ b/src/combinator.ts
@@ -121,6 +121,28 @@ export const objectP = <T extends object>(type: ObjectProxyHelper<T>): TypeProxy
   return { success: true, value: result as T };
 };
 
+export const recordP = <V>(valueType: TypeProxy<V>): TypeProxy<Record<string, V>> => (value) => {
+  if (typeof value !== 'object' || value === null) {
+    return { success: false, error: ParseError.simpleError(value, 'an object') };
+  }
+
+  const result: Record<string, V> = {};
+
+  for (const key of Object.keys(value)) {
+    const valueToCheck = (value as Record<string, unknown>)[key];
+    const fieldResult = valueType(valueToCheck);
+    if (!fieldResult.success) {
+      const fieldError = fieldResult.error;
+      fieldError.prefix(key);
+      return { success: false, error: fieldError };
+    } else {
+      result[key] = fieldResult.value;
+    }
+  }
+
+  return { success: true, value: result };
+};
+
 type TypeOfProxy<T> = T extends TypeProxy<infer U> ? U : never;
 type UnionOfTypes<T extends TypeProxy<unknown>[]> = TypeOfProxy<T[number]>;
 

--- a/test/javascript_proxy.js
+++ b/test/javascript_proxy.js
@@ -7,6 +7,7 @@ const {
   labelP,
   numberP,
   numLiteralP,
+  recordP,
   stringP,
   strLiteralP,
   objectP,
@@ -101,6 +102,19 @@ describe('Type Proxies', () => {
       }).success,
       false
     );
+  });
+
+  it('should parse records', () => {
+    const numOrNumArrayRecordP = recordP(orP(numberP, arrayP(numberP)));
+
+    assert(numOrNumArrayRecordP({
+      a: 123,
+      b: [1, 2, 3]
+    }).success);
+
+    assert.equal(numOrNumArrayRecordP({
+      a: [1, 'not-a-number', 3]
+    }).success, false);
   });
 
   it('validate should throw an error when a parse fails', () => {


### PR DESCRIPTION
This adds `recordP(T)` which gives you `Record<string, T>`.

Decided to keep it simple by taking only the value type-proxy. In the future we could add a second arg to support validating the key as well.
eg: `recordP(orP(strLiteralP('abc'), strLiteralP('xyz'), unknownP)` => `Record<'abc' | 'xyz', unknown>`